### PR TITLE
Fixing deployment by keeping `within` context intact

### DIFF
--- a/lib/capistrano/tasks/simplegit.rake
+++ b/lib/capistrano/tasks/simplegit.rake
@@ -16,13 +16,14 @@ namespace :simplegit do
             end
 
             within fetch(:simplegit_deploy) do
-                execute "cd #{fetch(:simplegit_deploy)} && git fetch"
+                execute :git, "fetch"
                 if test :git, :'show-branch', fetch(:simplegit_branch)
-                    execute "git checkout #{fetch(:simplegit_branch)} ; git reset --hard origin/#{fetch(:simplegit_branch)}"
+                  execute :git, "checkout #{fetch(:simplegit_branch)}"
+                  execute :git, "reset --hard origin/#{fetch(:simplegit_branch)}"
                 else
-                    execute "git checkout -b #{fetch(:simplegit_branch)} origin/#{fetch(:simplegit_branch)}"
+                  execute :git, "checkout -b #{fetch(:simplegit_branch)} origin/#{fetch(:simplegit_branch)}"
                 end
-                execute "git submodule update --init --recursive"
+                execute :git, "submodule update --init --recursive"
             end
         end
     end


### PR DESCRIPTION
The first argument to execute should not contain whitespace to not mangle with the `within` context. This is documented on http://capistranorb.com/documentation/getting-started/tasks/
